### PR TITLE
[bugfix] Add missing dependencies to pyproject file

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,8 @@ authors = ["p0dalirius"]
 python = "^3.7"
 impacket = "^0.10.0"
 xlsxWriter = ">=3.0.0"
+jinja2 = ">=3.1.3"
+sectools = ">1.4.3"
 
 [tool.poetry.dev-dependencies]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ python = "^3.7"
 impacket = "^0.10.0"
 xlsxWriter = ">=3.0.0"
 jinja2 = ">=3.1.3"
-sectools = ">1.4.3"
+sectools = ">=1.4.3"
 
 [tool.poetry.dev-dependencies]
 


### PR DESCRIPTION
Hi,

You forgot the `jinja2` and `sectools` dependencies into the pyproject.toml file.

**Fail :**

```bash
[Apr 04, 2024 - 12:03:27 (CEST)] exegol-ctf4 /workspace # pipx install --system-site-packages git+https://github.com/p0dalirius/Coercer
  installed package coercer 2.4.3, installed using Python 3.11.8
  These apps are now globally available
    - coercer
done! ✨ 🌟 ✨
```

```bash
[Apr 04, 2024 - 12:04:46 (CEST)] exegol-ctf4 /workspace # coercer
Traceback (most recent call last):
  File "/root/.local/bin/coercer", line 5, in <module>
    from coercer.__main__ import main
  File "/root/.local/share/pipx/venvs/coercer/lib/python3.11/site-packages/coercer/__main__.py", line 11, in <module>
    from sectools.network.domains import is_fqdn
ModuleNotFoundError: No module named 'sectools'
```

**Works :**

```bash
[Apr 04, 2024 - 12:01:37 (CEST)] exegol-ctf4 /workspace # pipx install --system-site-packages git+https://github.com/QU35T-code/Coercer@fix/pytoml
  installed package coercer 2.4.3, installed using Python 3.11.8
  These apps are now globally available
    - coercer
done! ✨ 🌟 ✨
```

```bash
[Apr 04, 2024 - 12:01:55 (CEST)] exegol-ctf4 /workspace # coercer
       ______
      / ____/___  ___  _____________  _____
     / /   / __ \/ _ \/ ___/ ___/ _ \/ ___/
    / /___/ /_/ /  __/ /  / /__/  __/ /      v2.4.3
    \____/\____/\___/_/   \___/\___/_/       by @podalirius_

usage: coercer [-h] [-v] {scan,coerce,fuzz} ...
coercer: error: the following arguments are required: mode
```

_Catched by the Exegol pipeline_