### PR TITLE
[bugfix] HTTP scan coerced authentication against wrong port

### DIFF
--- a/coercer/core/tasks/execute.py
+++ b/coercer/core/tasks/execute.py
@@ -146,7 +146,7 @@ def execute_tasks(
                                         or options.listener_ip),
                                         http_listen_port=(
                                             http_listen_port
-                                            if mode == Modes.FUZZ
+                                            if mode == Modes.FUZZ or mode == Modes.SCAN
                                             else options.http_port
                                         ),
                                         smb_listen_port=options.smb_port,


### PR DESCRIPTION
I noticed that I didn't get any HTTP requests in even though the victim had the WebDAV client active. In Wireshark,  however, I could see incoming requests on port 80. The script on the other hand opened ports on random high-ports. I'm not familiar with the code base, but this seems to fix the problem.